### PR TITLE
Add a fallback when images cannot be loaded in cache

### DIFF
--- a/angular-imgcache.js
+++ b/angular-imgcache.js
@@ -44,16 +44,19 @@ angular.module('ImgCache', [])
             icSrc: '@'
         },
         link: function(scope, el, attrs) {
+            var setImg = function(type, el, img_src) {
+                if (type === 'bg') {
+                    el.css({'background-image': 'url(' + img_src + ')'});
+                } else {
+                    el.attr('src', img_src);
+                }
+            };
 
-            var setImg = function(type, el, src) {
+            var setImgFromCache = function(type, el, src) {
 
                 ImgCache.getCachedFileURL(src, function(src, dest) {
                     var img_src = dest.fullPath.replace('/'. ImgCache.options.localCacheFolder, ImgCache.getCacheFolderURI());
-                    if(type === 'bg') {
-                        el.css({'background-image': 'url(' + img_src + ')' });
-                    } else {
-                        el.attr('src', img_src);
-                    }
+                    setImg(type, el, img_src);
                 });
             };
 
@@ -64,9 +67,11 @@ angular.module('ImgCache', [])
                     ImgCache.isCached(src, function(path, success) {
 
                         if (success) {
-                            setImg(type, el, src);
+                            setImgFromCache(type, el, src);
                         } else {
                             ImgCache.cacheFile(src, function() {
+                                setImgFromCache(type, el, src);
+                            }, function() {
                                 setImg(type, el, src);
                             });
                         }

--- a/angular-imgcache.js
+++ b/angular-imgcache.js
@@ -9,17 +9,17 @@ angular.module('ImgCache', [])
         }, function() {
             ImgCache.$deferred.reject();
         });
-    }
+    };
 
     this.manualInit = false;
 
     this.setOptions = function(options) {
         angular.extend(ImgCache.options, options);
-    }
+    };
 
     this.setOption = function(name, value) {
         ImgCache.options[name] = value;
-    }
+    };
 
     this.$get = ['$q', function ($q) {
 
@@ -55,7 +55,7 @@ angular.module('ImgCache', [])
                         el.attr('src', img_src);
                     }
                 });
-            }
+            };
 
             var loadImg = function(type, el, src) {
 
@@ -73,7 +73,7 @@ angular.module('ImgCache', [])
 
                     });
                 });
-            }
+            };
 
             attrs.$observe('icSrc', function(src) {
 


### PR DESCRIPTION
ImgCache uses XHR to load images. But XHR requests are constrained by the cross domain policy.

If images come from another domain and this domain does not implement CORS, they cannot be loaded for security reasons.

This pull requests adds a fallback to insert the image URL in the `src` attribute instead of letting the `src` attribute blank. Of course it won't be cached but in my use case it is better than displaying an image without `src`.
